### PR TITLE
docs: mark project as stale, point to W3C-maintained WCAG JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # WCAG as JSON
 
+> [!WARNING]
+> **This project is stale and no longer maintained.**
+>
+> If you are looking for a JSON representation of WCAG, please use the officially maintained version from the W3C instead:
+>
+> **<https://github.com/w3c/wcag/tree/main/11ty/json>**
+>
+> This repository is left online for historical reference only and will not receive further updates.
+
 This is a JSON formatted version of WCAG 2.2
 
 We created this as a way to be able to quickly insert references to WCAG-related information into other documents.


### PR DESCRIPTION
## Summary

Adds a prominent deprecation notice to the top of the README declaring that this project is **stale and no longer maintained**, and directing users to the officially maintained WCAG JSON from the W3C:

- <https://github.com/w3c/wcag/tree/main/11ty/json>

## Changes

- `README.md`: Added a `> [!WARNING]` callout at the top noting the project is unmaintained, linking to the W3C-maintained version, and clarifying the repo remains online for historical reference only.

## Notes

- Documentation-only change; no code or data (`wcag.json`) modified.
- Passes `markdownlint`.